### PR TITLE
Updated dependencies for 1.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'fabric-loom' version '0.9-SNAPSHOT'
+    id 'fabric-loom' version '0.10-SNAPSHOT'
     id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.17.1
-yarn_mappings=1.17.1+build.22
-loader_version=0.11.6
+minecraft_version=1.18.1
+yarn_mappings=1.18.1+build.17
+loader_version=0.12.12
 # Mod Properties
 mod_version=1.1.0
 maven_group=com.frogastudios
 archives_base_name=storagerecursion
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.37.0+1.17
+fabric_version=0.45.1+1.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=1.17.1
-yarn_mappings=1.17.1+build.22
-loader_version=0.11.6
+yarn_mappings=1.17.1+build.63
+loader_version=0.11.7
 # Mod Properties
 mod_version=1.1.0
 maven_group=com.frogastudios
 archives_base_name=storagerecursion
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.37.0+1.17
+fabric_version=0.42.1+1.17

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.17
-loader_version=0.12.12
+minecraft_version=1.17.1
+yarn_mappings=1.17.1+build.63
+loader_version=0.11.7
 # Mod Properties
 mod_version=1.1.0
 maven_group=com.frogastudios
 archives_base_name=storagerecursion
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.45.1+1.18
+fabric_version=0.42.1+1.17

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,8 +25,8 @@
     "storagerecursion.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.12.12",
+    "fabricloader": ">=0.11.7",
     "fabric": "*",
-    "minecraft": "1.18.1"
+    "minecraft": "1.17.1"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,8 +25,8 @@
     "storagerecursion.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.11.6",
+    "fabricloader": ">=0.12.12",
     "fabric": "*",
-    "minecraft": "1.17.1"
+    "minecraft": "1.18.1"
   }
 }


### PR DESCRIPTION
Updated to latest fabric api that supports loader < 0.12.x (Some mods do not support >=0.12.x, so this does not break compatibility).